### PR TITLE
shovel-config-ts: update types to match documentation

### DIFF
--- a/shovel-config-ts/build-instructions.txt
+++ b/shovel-config-ts/build-instructions.txt
@@ -1,5 +1,7 @@
 Here are set of commonly used commands for this project:
 
+bun install
+
 bun run build
 bun link @indexsupply/shovel-config
 

--- a/shovel-config-ts/src/index.ts
+++ b/shovel-config-ts/src/index.ts
@@ -37,7 +37,9 @@ export type Table = {
   index?: IndexStatment[];
 };
 
-export type FilterOp = "contains" | "!contains";
+export type FilterRefOp = "contains" | "!contains";
+
+export type FilterArgOp = FilterRefOp | "eq" | "ne" | "gt" | "lt";
 
 export type FilterReference = {
   integration: string;
@@ -45,7 +47,7 @@ export type FilterReference = {
 };
 
 export type Filter = {
-  op: FilterOp;
+  op: FilterRefOp;
   arg: Hex[];
 };
 
@@ -65,6 +67,13 @@ export type BlockDataOptions =
   | "tx_type"
   | "tx_status"
   | "log_idx"
+  | "tx_gas_used"
+  | "tx_gas_price"
+  | "tx_effective_gas_price"
+  | "tx_contract_address"
+  | "tx_max_priority_fee_per_gas"
+  | "tx_max_fee_per_gas"
+  | "tx_nonce"
   | "log_addr"
   | "trace_action_call_type"
   | "trace_action_idx"
@@ -81,10 +90,13 @@ export type BlockData = {
   name: BlockDataOptions;
 
   column: string;
-  filter_op?: FilterOp;
+} & ({
+  filter_op?: FilterArgOp;
   filter_arg?: Hex[];
+} | {
+  filter_op?: FilterRefOp;
   filter_ref?: FilterReference;
-};
+});
 
 /**
  * EventInput is a superset of the ABI JSON defintion for event
@@ -108,10 +120,13 @@ export type EventInput = {
   readonly components?: EventInput[];
 
   column?: string;
-  filter_op?: FilterOp;
+} & ({
+  filter_op?: FilterArgOp;
   filter_arg?: Hex[];
+} | {
+  filter_op?: FilterRefOp;
   filter_ref?: FilterReference;
-};
+});
 
 export type Event = {
   readonly name: string;


### PR DESCRIPTION
I was attempting to use [@indexsupply/shovel-config](https://www.npmjs.com/package/@indexsupply/shovel-config) to make a shovel config in TypeScript but was running into type errors.

Upon further investigation, it appeared that the TypeScript types in the `shovel-config-ts` subproject were out of date with the current version of the `shovel` indexer in the repo. Specifically:

* Some of the block data options in `dig.go` were not present in the `BlockDataOptions` type in Typescript (e.g. `tx_contract_address`, `tx_max_priority_fee_per_gas`): 

    https://github.com/indexsupply/shovel/blob/cb9264ec081c598c1ceee65ff08485e304b111a2/dig/dig.go#L896-L962

    https://github.com/indexsupply/shovel/blob/cb9264ec081c598c1ceee65ff08485e304b111a2/shovel-config-ts/src/index.ts#L52-L73

* The `FilterOp` type was missing the filter ops corresponding to a config with `filter_arg`, as outlined in the docs under the "Filter Fields" section: https://indexsupply.com/shovel/docs/#filter-fields

    <img width="718" alt="Screenshot 2024-12-06 at 15 41 48" src="https://github.com/user-attachments/assets/ccbbe71d-e49d-4f2b-83af-96166bafc097">

To fix this, I added the missing options to the TypeScript types. I also added the `bun install` command to the build instructions, as the build was failing when I initially cloned the repo to test locally since I hadn't installed any of the dependencies.

When testing my shovel config with the updated types in this PR, the type errors were no longer present.