### PR TITLE
shovel-config-ts: allow filter_arg to take empty string

### DIFF
--- a/shovel-config-ts/src/index.ts
+++ b/shovel-config-ts/src/index.ts
@@ -8,7 +8,6 @@
 type EnvRef = `$${string}`;
 
 type Hex = `0x${string}`;
-type HexOrNull = Hex | "";
 
 export type PGColumnType =
   | "bigint"
@@ -49,7 +48,7 @@ export type FilterReference = {
 
 export type Filter = {
   op: FilterRefOp;
-  arg: HexOrNull[];
+  arg: string[];
 };
 
 export type BlockDataOptions =
@@ -93,7 +92,7 @@ export type BlockData = {
   column: string;
 } & ({
   filter_op?: FilterArgOp;
-  filter_arg?: HexOrNull[];
+  filter_arg?: string[];
 } | {
   filter_op?: FilterRefOp;
   filter_ref?: FilterReference;
@@ -123,7 +122,7 @@ export type EventInput = {
   column?: string;
 } & ({
   filter_op?: FilterArgOp;
-  filter_arg?: HexOrNull[];
+  filter_arg?: string[];
 } | {
   filter_op?: FilterRefOp;
   filter_ref?: FilterReference;

--- a/shovel-config-ts/src/index.ts
+++ b/shovel-config-ts/src/index.ts
@@ -8,6 +8,7 @@
 type EnvRef = `$${string}`;
 
 type Hex = `0x${string}`;
+type HexOrNull = Hex | "";
 
 export type PGColumnType =
   | "bigint"
@@ -48,7 +49,7 @@ export type FilterReference = {
 
 export type Filter = {
   op: FilterRefOp;
-  arg: Hex[];
+  arg: HexOrNull[];
 };
 
 export type BlockDataOptions =
@@ -92,7 +93,7 @@ export type BlockData = {
   column: string;
 } & ({
   filter_op?: FilterArgOp;
-  filter_arg?: Hex[];
+  filter_arg?: HexOrNull[];
 } | {
   filter_op?: FilterRefOp;
   filter_ref?: FilterReference;
@@ -122,7 +123,7 @@ export type EventInput = {
   column?: string;
 } & ({
   filter_op?: FilterArgOp;
-  filter_arg?: Hex[];
+  filter_arg?: HexOrNull[];
 } | {
   filter_op?: FilterRefOp;
   filter_ref?: FilterReference;


### PR DESCRIPTION
In https://github.com/indexsupply/shovel/pull/277, a feature was introduced which made empty string values `""` in `filter_arg` correspond to `null` when decoded. This change was not reflected in the TypeScript types for the shovel-config-ts config generator; this PR changes the types to allow `filter_arg` to take an empty string value.

When testing my shovel config with the updated types in this PR, I was successfully able to add `""` to a `filter_arg` without type errors.

Something to consider — in [the docs](https://indexsupply.com/shovel/docs/), it says:

> `filter_arg`: Not required when using filter_ref. Use filter_arg when you want to filter on static data. Must be an array of strings. The string values will be decoded depending on the value of comparison. Namely, a string with a 0x prefix will be decoded into bytes, a decimal string will be decoded into uint or int, a string of utf8 characters will be decoded into a string, and an empty string will be decoded as an empty value of the type being compared.

Should the type actually be expanded to `(Hex | string)[]` here, or even just `string[]`?