### PR TITLE
feat: add support for op-stack specific receipt fields (#1)

### DIFF
--- a/dig/dig.go
+++ b/dig/dig.go
@@ -944,6 +944,18 @@ func (lwc *logWithCtx) get(name string) any {
 		return &lwc.t.MaxFeePerGas
 	case "tx_nonce":
 		return lwc.t.Nonce
+	case "tx_l1_base_fee_scalar":
+		return lwc.t.L1BaseFeeScalar
+	case "tx_l1_blob_base_fee":
+		return lwc.t.L1BlobBaseFee
+	case "tx_l1_blob_base_fee_scalar":
+		return lwc.t.L1BlobBaseFeeScalar
+	case "tx_l1_fee":
+		return lwc.t.L1Fee
+	case "tx_l1_gas_price":
+		return lwc.t.L1GasPrice
+	case "tx_l1_gas_used":
+		return lwc.t.L1GasUsed
 	case "log_addr":
 		return lwc.l.Address.Bytes()
 	case "trace_action_call_type":

--- a/eth/types.go
+++ b/eth/types.go
@@ -173,6 +173,12 @@ type Receipt struct {
 	EffectiveGasPrice uint256.Int
 	Logs              Logs
 	ContractAddress   Bytes
+	L1BaseFeeScalar     *uint256.Int `json:"l1BaseFeeScalar,omitempty"`
+	L1BlobBaseFee       *uint256.Int `json:"l1BlobBaseFee,omitempty"`
+	L1BlobBaseFeeScalar *uint256.Int `json:"l1BlobBaseFeeScalar,omitempty"`
+	L1Fee               *uint256.Int `json:"l1Fee,omitempty"`
+	L1GasPrice          *uint256.Int `json:"l1GasPrice,omitempty"`
+	L1GasUsed           *Uint64      `json:"l1GasUsed,omitempty"`
 }
 
 type Header struct {

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -655,6 +655,12 @@ type receiptResult struct {
 	EffectiveGasPrice uint256.Int `json:"effectiveGasPrice"`
 	Logs              eth.Logs    `json:"logs"`
 	ContractAddress   eth.Bytes   `json:"contractAddress"`
+	L1BaseFeeScalar     *uint256.Int `json:"l1BaseFeeScalar,omitempty"`
+	L1BlobBaseFee       *uint256.Int `json:"l1BlobBaseFee,omitempty"`
+	L1BlobBaseFeeScalar *uint256.Int `json:"l1BlobBaseFeeScalar,omitempty"`
+	L1Fee               *uint256.Int `json:"l1Fee,omitempty"`
+	L1GasPrice          *uint256.Int `json:"l1GasPrice,omitempty"`
+	L1GasUsed           *eth.Uint64  `json:"l1GasUsed,omitempty"`
 }
 
 type receiptResp struct {
@@ -712,6 +718,12 @@ func (c *Client) receipts(ctx context.Context, url string, bm blockmap, start, l
 			tx.Logs = make([]eth.Log, len(resps[i].Result[j].Logs))
 			tx.ContractAddress.Write(resps[i].Result[j].ContractAddress)
 			copy(tx.Logs, resps[i].Result[j].Logs)
+			tx.L1BaseFeeScalar = resps[i].Result[j].L1BaseFeeScalar
+			tx.L1BlobBaseFee = resps[i].Result[j].L1BlobBaseFee
+			tx.L1BlobBaseFeeScalar = resps[i].Result[j].L1BlobBaseFeeScalar
+			tx.L1Fee = resps[i].Result[j].L1Fee
+			tx.L1GasPrice = resps[i].Result[j].L1GasPrice
+			tx.L1GasUsed = resps[i].Result[j].L1GasUsed
 		}
 	}
 	return nil

--- a/shovel/glf/filter.go
+++ b/shovel/glf/filter.go
@@ -127,6 +127,12 @@ var (
 		"tx_status",
 		"tx_gas_used",
 		"tx_contract_address",
+		"tx_l1_base_fee_scalar",
+		"tx_l1_blob_base_fee",
+		"tx_l1_blob_base_fee_scalar",
+		"tx_l1_fee",
+		"tx_l1_gas_price",
+		"tx_l1_gas_used",
 		"log_addr",
 		"log_idx",
 	}


### PR DESCRIPTION
OP Stack based chains expose additional fields on the transaction receipt for L1 fee related things. This PR adds support for indexing those fields to shovel.

Example receipt:

```
> cast rpc eth_getTransactionReceipt '0x7d5f1c9c6e8f0ab1cb693894b6ec90f1b2bd31211d590747c26e76404850cf1a' --rpc-url https://rpc.redstonechain.com | jq

{
  "blockHash": "0xf9147ac51575086a27674bb46e2b30f2c6b54c2919ea2f8d295aced41eea6cfa",
  "blockNumber": "0x11e3714",
  "contractAddress": null,
  "cumulativeGasUsed": "0x541ed",
  "effectiveGasPrice": "0x2742",
  "from": "0xf83c1abab092b4f6ae80299964b1f57fffd40135",
  "gasUsed": "0x4760e",
  "l1BaseFeeScalar": "0xbf9",
  "l1BlobBaseFee": "0x1",
  "l1BlobBaseFeeScalar": "0x0",
  "l1Fee": "0x74c3eb934",
  "l1GasPrice": "0x40c31dfc",
  "l1GasUsed": "0x24c4",
  "logs": [...],
  "logsBloom": "0x000...",
  "status": "0x1",
  "to": "0x0000000071727de22e5e9d8baf0edac6f37da032",
  "transactionHash": "0x7d5f1c9c6e8f0ab1cb693894b6ec90f1b2bd31211d590747c26e76404850cf1a",
  "transactionIndex": "0x1",
  "type": "0x2"
}

```