### PR TITLE
fix: dig panic on empty inputs events

### DIFF
--- a/dig/dig.go
+++ b/dig/dig.go
@@ -957,6 +957,9 @@ func (lwc *logWithCtx) get(name string) any {
 	case "tx_l1_gas_used":
 		return lwc.t.L1GasUsed
 	case "log_addr":
+		if lwc.l == nil {
+			return nil
+		}
 		return lwc.l.Address.Bytes()
 	case "trace_action_call_type":
 		return lwc.ta.CallType


### PR DESCRIPTION
## Fix segmentation fault when processing events with empty inputs

**Fixes #288**

### Problem
Shovel was crashing with a segmentation fault when processing events that have an empty `inputs` array. The panic occurred due to a nil pointer dereference in `dig/dig.go` at line 975 during log processing.

### Root Cause
The `logWithCtx.get()` method was attempting to access `lwc.l.Address` without checking if `lwc.l` was nil, causing a segmentation fault when processing certain event configurations.

### Solution
Added a nil check for `lwc.l` in the `logWithCtx.get()` method before accessing the log address:

```go
case "log_addr":
    if lwc.l == nil {
        return nil
    }
    return lwc.l.Address.Bytes()
```
### Note

This is my first time looking at this codebase, so I'm not entirely certain this is the most appropriate fix, but it resolves the immediate crash. I'd appreciate feedback on whether this approach aligns with the intended behavior or if there's a more comprehensive solution needed.
