### PR TITLE
fix: delete data down to the remaining watermark on reorg

### DIFF
--- a/shovel/task.go
+++ b/shovel/task.go
@@ -231,6 +231,17 @@ func (t *Task) update(
 	return err
 }
 
+// Delete removes the task updates at or above n and the destination's data
+// for every block those updates covered.
+//
+// [Task.update] writes one shovel.task_updates row per converge batch and sets
+// num to the batch's LAST block, so a single update covers (previous update,
+// num]. Deleting data at >= n only would therefore keep the deleted batch's
+// canonical prefix -- blocks below n that no remaining update accounts for.
+// Converge resumes from the highest remaining update and requests those blocks
+// again, and since [Destination.Insert] uses COPY (no on conflict), the retry
+// fails against the destination's unique index forever: the task stops making
+// progress until the leftover rows are deleted by hand.
 func (t *Task) Delete(pg wpg.Conn, n uint64) error {
 	const q = `
 		delete from shovel.task_updates
@@ -242,15 +253,49 @@ func (t *Task) Delete(pg wpg.Conn, n uint64) error {
 	if err != nil {
 		return fmt.Errorf("deleting block from task table: %w", err)
 	}
-	err = t.dests[0].Delete(t.ctx, pg, n)
+	dn, err := t.resume(pg, n)
+	if err != nil {
+		return err
+	}
+	err = t.dests[0].Delete(t.ctx, pg, dn)
 	if err != nil {
 		return fmt.Errorf("deleting block: %w", err)
 	}
 	slog.InfoContext(t.ctx, "task-delete",
 		"n", n,
+		"data_n", dn,
 		"task_updates", cmd.RowsAffected(),
 	)
 	return nil
+}
+
+// resume reports the first block Converge will request once the task updates
+// at or above n are gone: one past the highest remaining update. It is never
+// greater than n, since no update at or above n survives the delete.
+//
+// With no updates left the task restarts at its configured start, or -- absent
+// one -- at the chain head, which is above anything already stored. Both cases
+// fall back to n rather than deleting the destination's whole history.
+func (t *Task) resume(pg wpg.Conn, n uint64) (uint64, error) {
+	const q = `
+		select coalesce(max(num) + 1, 0)
+		from shovel.task_updates
+		where src_name = $1
+		and ig_name = $2
+	`
+	var num uint64
+	err := pg.QueryRow(t.ctx, q, t.srcName, t.destConfig.Name).Scan(&num)
+	if err != nil {
+		return 0, fmt.Errorf("querying remaining task updates: %w", err)
+	}
+	switch {
+	case num > 0:
+		return num, nil
+	case t.start > 0:
+		return t.start, nil
+	default:
+		return n, nil
+	}
 }
 
 func (t *Task) latestDependency(pg wpg.Conn) (uint64, []byte, error) {

--- a/shovel/task_test.go
+++ b/shovel/task_test.go
@@ -64,6 +64,12 @@ func (dest *testDestination) Insert(_ context.Context, _ *sync.Mutex, _ wpg.Conn
 	dest.Lock()
 	defer dest.Unlock()
 	for _, b := range blocks {
+		// [dig.Integration.Insert] copies into a table with a unique index
+		// and has no on conflict clause, so re-inserting a block that was
+		// never deleted is an error rather than an overwrite.
+		if _, ok := dest.chain[b.Num()]; ok {
+			return 0, fmt.Errorf("duplicate key: %d", b.Num())
+		}
 		dest.chain[uint64(b.Header.Number)] = b
 	}
 	return int64(len(blocks)), nil
@@ -84,7 +90,12 @@ func (dest *testDestination) add(n uint64, hash, parent []byte) {
 func (dest *testDestination) Delete(_ context.Context, pg wpg.Conn, n uint64) error {
 	dest.Lock()
 	defer dest.Unlock()
-	delete(dest.chain, n)
+	// [dig.Integration.Delete] deletes at block_num >= n, not just n.
+	for num := range dest.chain {
+		if num >= n {
+			delete(dest.chain, num)
+		}
+	}
 	return nil
 }
 
@@ -214,6 +225,45 @@ func TestConverge_Reorg(t *testing.T) {
 
 	diff.Test(t, t.Fatalf, nil, task.update(pg, 0, hash(0), 0, hash(0), 0, 0, 0))
 	diff.Test(t, t.Fatalf, nil, task.update(pg, 1, hash(1), 0, hash(0), 0, 0, 0))
+
+	diff.Test(t, t.Fatalf, task.Converge(), nil)
+	diff.Test(t, t.Fatalf, task.Converge(), nil)
+	diff.Test(t, t.Errorf, dest.blocks(), tg.blocks)
+}
+
+// A converge batch writes one task update for its last block. When that block
+// is reorged out, the batch's earlier blocks have to go too -- no remaining
+// update covers them, and converge requests them again on the next pass.
+func TestConverge_ReorgBatchPrefix(t *testing.T) {
+	var (
+		pg        = testpg(t)
+		tg        = &testGeth{}
+		dest      = newTestDestination("foo")
+		task, err = NewTask(
+			WithPG(pg),
+			WithConcurrency(1, 2),
+			WithSource(tg),
+			WithIntegration(dest.ig()),
+			WithIntegrationFactory(dest.factory),
+		)
+	)
+	diff.Test(t, t.Fatalf, err, nil)
+
+	tg.add(0, hash(0), hash(0))
+	tg.add(1, hash(1), hash(0))
+	tg.add(2, hash(2), hash(1))
+	dest.add(0, hash(0), hash(0))
+	diff.Test(t, t.Fatalf, nil, task.update(pg, 0, hash(0), 0, hash(0), 0, 0, 0))
+
+	// blocks 1 and 2 land in one batch, covered by a single update at 2
+	diff.Test(t, t.Fatalf, task.Converge(), nil)
+	checkQuery(t, pg, `select max(num) = 2 from shovel.task_updates`)
+
+	// block 2 is reorged out. block 1 stays canonical, but the update that
+	// covered it is deleted along with 2, so it must be reindexed.
+	tg.blocks = tg.blocks[:2]
+	tg.add(2, hash(22), hash(1))
+	tg.add(3, hash(3), hash(22))
 
 	diff.Test(t, t.Fatalf, task.Converge(), nil)
 	diff.Test(t, t.Fatalf, task.Converge(), nil)


### PR DESCRIPTION
# fix: delete data down to the remaining watermark on reorg

## Problem

A reorg can permanently wedge a single integration. It stops converging and logs this
forever, ~26 retries/sec, until someone deletes rows by hand:

```
msg=converge-retry ig=uniswap_v3_swap msg=inserting data: inserting blocks:
ERROR: duplicate key value violates unique constraint "u_evm_uniswap_v3_swap" (SQLSTATE 23505)
```

Sibling integrations on the same source keep converging, so it reads as a
single-integration failure rather than a reorg. Restarting does not help, because the
conflicting rows are already committed.

## Cause

`Task.update` writes **one** `shovel.task_updates` row per converge batch, with `num` set
to the batch's **last** block (`task.go:443`). One update therefore covers the whole range
`(previous update, num]`.

`Task.Delete(n)` removes updates at `num >= n` but tells the destination to delete at
`block_num >= n`. When the batch spans more than one block, the blocks below `n` in that
same batch keep their data while the watermark rewinds below them — they are the batch's
**canonical prefix**, not orphaned-chain data, since only `n` and above were reorged out.

`Converge` then resumes from the highest remaining update and re-requests those blocks.
`dig.Integration.Insert` uses `CopyFrom`, which cannot express `on conflict`, so the insert
hits `u_<table>` and rolls back. Every subsequent poll repeats it.

The window is `batchSize > 1`, which is the normal case: with a 2-block batch it is roughly
a coin flip per reorg. Concretely, from a production instance on mainnet:

```
watermark (task_updates.num)   25666514
orphan rows in evm_uniswap_v3_swap   2, at blocks 25666516 and 25666517
```

The update at 25666518 was deleted along with data `>= 25666518`; blocks 25666516–17 from
that same batch survived below the rewound watermark. Deleting exactly those two rows
unwedged the integration with no restart, and Shovel re-inserted them byte-identically
(md5 of every re-inserted row matched the pre-delete capture), which confirms they were
canonical rather than reorged data.

## Fix

`Task.Delete` now asks where `Converge` will actually resume — one past the highest
**remaining** update — and deletes destination data from there, so no block is ever left
without an update covering it. The new `resume` value is never greater than `n` (no update
at or above `n` survives the delete), so this only ever widens the delete, and only within
a batch that was already being discarded.

With no updates left, the task restarts at its configured start, or at the chain head when
there is none; both are above anything already stored, so that case falls back to `n`
rather than deleting the destination's whole history.

Re-indexing a batch's earlier blocks is the same work the task was already about to do —
it re-requests that range from the node either way.

## Tests

- `TestConverge_ReorgBatchPrefix` (new): one update covering blocks 1–2, block 2 reorged
  out, asserts the task converges to the canonical chain. Without the `task.go` change it
  fails with `inserting data: inserting blocks: duplicate key: 1` — the same shape as the
  production error above.
- `testDestination` was too permissive to catch this and needed two fixes to match
  `dig.Integration`: `Delete` now deletes at `>= n` rather than the single key `n`, and
  `Insert` reports a duplicate instead of silently overwriting, since the real destination
  copies into a table with a unique index and no `on conflict`. The existing
  `TestConverge_Reorg` passes under both, because it writes one update per block, so
  batch-granularity never comes into play.
- Full suite green (`go test -p 1 ./...`, postgres 15 via pqxtest).

## Alternatives considered

- **One `task_updates` row per block.** Removes the granularity mismatch at its root, but
  multiplies watermark writes by the batch size.
- **`on conflict do nothing` on insert.** Not expressible through `CopyFrom`, and it would
  mask genuine duplicates.
